### PR TITLE
feat: add pose landmarker extraction and Streamlit wiring

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,72 +1,69 @@
-import io
-import time
 import yaml
 import streamlit as st
 
+from ml.pose3d import extract
+
 st.set_page_config(page_title="Squat MVP", layout="wide")
 
-# Load config once
+
 @st.cache_resource
 def load_cfg():
     with open("config/default.yml", "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _clear_error() -> None:
+    if "analysis_error" in st.session_state:
+        del st.session_state["analysis_error"]
+
+
+def _set_error(message: str) -> None:
+    st.session_state["analysis_error"] = message
+    if "series" in st.session_state:
+        del st.session_state["series"]
+
 
 cfg = load_cfg()
 
 st.title("AI-Powered Exercise Technique Analyzer — MVP")
 st.caption("Streamlit + MediaPipe 3D | CPU-only | Frontal & Lateral views")
 
-
-# Sidebar controls
 view = st.sidebar.selectbox("Camera view", ["Lateral", "Frontal"], index=0)
-st.sidebar.markdown("**Config snapshot**")  # light peek for debugging
+st.session_state["view"] = view
+st.sidebar.markdown("**Config snapshot**")
 st.sidebar.json({"fps_cap": cfg.get("fps_cap"), "smoothing_alpha": cfg.get("smoothing_alpha")})
 
-uploaded = st.file_uploader("Upload a short squat video (.mp4/.mov)", type=["mp4", "mov"])  # noqa: E501
-
+uploaded = st.file_uploader("Upload a short squat video (.mp4/.mov)", type=["mp4", "mov"])
 analyze = st.button("Analyze", type="primary", disabled=uploaded is None)
 
-tabs = st.tabs(["Overview", "Per-Rep", "Visuals", "Export"])  # placeholders
+tabs = st.tabs(["Overview", "Per-Rep", "Visuals", "Export"])
 
 if analyze and uploaded is not None:
-    with st.spinner("Running analysis (pose → preprocess → segment → KPIs → faults)…"):
-        time.sleep(0.5)  # placeholder for pipeline latency
-        # TODO: call the pipeline functions once implemented (per 02_TASK_LIST.md)
-        # from ml.pose3d import extract
-        # from ml.preprocess import clean
-        # from ml.segment import segment
-        # from ml.kpi import compute
-        # from ml.faults import detect
-        # from ml.feedback import to_text
-        # series = extract(uploaded, cfg)
-        # series = clean(series, cfg)
-        # windows = segment(series, cfg)
-        # rep_metrics = compute(series, windows, cfg, view)
-        # flags = [detect(m, cfg, view) for m in rep_metrics]
-        # feedback = [to_text(f, view) for f in flags]
-        st.session_state["_demo_results"] = {
-            "rep_count": 3,
-            "avg_knee_angle_deg": 98.7,
-            "faults": {"insufficient_depth": 1, "knee_valgus": 0, "excessive_trunk_lean": 1},
-            "view": view
-        }
+    with st.spinner("Running pose extraction…"):
+        try:
+            series = extract(uploaded, cfg)
+        except Exception as exc:  # pragma: no cover - UI side effect
+            _set_error(str(exc))
+        else:
+            st.session_state["series"] = series
+            _clear_error()
 
-if "_demo_results" in st.session_state:
-    res = st.session_state["_demo_results"]
-    with tabs[0]:
-        col1, col2, col3 = st.columns(3)
-        col1.metric("Rep count", res["rep_count"])
-        col2.metric("Avg knee angle (°)", f"{res['avg_knee_angle_deg']:.1f}")
-        col3.json(res["faults"])
+series = st.session_state.get("series")
+error = st.session_state.get("analysis_error")
 
-    with tabs[1]:
-        st.write("Per-rep table — placeholder (to be filled by pipeline output)")
-
-    with tabs[2]:
-        st.write("Visuals — placeholder for overlay player and angle charts")  # charts must use matplotlib without custom colors
-
-    with tabs[3]:
-        st.download_button("Download CSV (placeholder)", data="rep,depth_ok\n1,True\n2,False\n3,True\n", file_name="results_demo.csv", mime="text/csv")  # noqa: E501
-else:
-    with tabs[0]:
+with tabs[0]:
+    if series is not None:
+        st.success(f"Frames processed: {len(series['frames'])}")
+    elif error:
+        st.error(error)
+    else:
         st.info("Upload a video and click Analyze to see results.")
+
+with tabs[1]:
+    st.write("Per-rep table — pending downstream pipeline")
+
+with tabs[2]:
+    st.write("Visuals — pending downstream pipeline")
+
+with tabs[3]:
+    st.write("Export options will appear once the pipeline is complete.")

--- a/docs/02_TASK_LIST.md
+++ b/docs/02_TASK_LIST.md
@@ -261,4 +261,5 @@ Examples:
 
 <!-- === BEGIN: AGENT-EDITABLE TASK COMPLETION LEDGER === -->
 <!-- (append completed task entries below this line) -->
+[2025-10-08] T02.1–T02.3 — [DONE] — Pose3D extract() returns PoseTimeSeries; wired to app
 <!-- === END: AGENT-EDITABLE TASK COMPLETION LEDGER === -->

--- a/ml/pose3d.py
+++ b/ml/pose3d.py
@@ -1,1 +1,192 @@
-"""Pose3D wrapper for MediaPipe Tasks — Pose Landmarker 3D (to be implemented)."""
+"""Pose extraction utilities using MediaPipe Pose Landmarker 3D."""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
+
+import cv2
+import mediapipe as mp
+import numpy as np
+from mediapipe.solutions.pose import PoseLandmark
+from mediapipe.tasks import python
+from mediapipe.tasks.python import vision
+
+__all__ = ["iter_frames", "extract"]
+
+logger = logging.getLogger(__name__)
+
+
+VideoInput = Union[str, os.PathLike[str], io.BufferedIOBase, io.BytesIO]
+FrameYield = Tuple[np.ndarray, int, int, float]
+
+
+def _resolve_video_input(video_input: VideoInput) -> Tuple[str, Optional[Callable[[], None]]]:
+    """Return a filesystem path for ``video_input`` and an optional cleanup callback."""
+
+    if isinstance(video_input, (str, os.PathLike)):
+        path = Path(video_input).expanduser().resolve()
+        return str(path), None
+
+    if hasattr(video_input, "read"):
+        data = video_input.read()
+        if hasattr(video_input, "seek"):
+            try:
+                video_input.seek(0)
+            except (OSError, AttributeError):
+                pass
+        suffix = Path(getattr(video_input, "name", "upload.mp4")).suffix or ".mp4"
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
+            tmp.write(data)
+            tmp.flush()
+        finally:
+            tmp.close()
+
+        def _cleanup() -> None:
+            try:
+                os.remove(tmp.name)
+            except OSError:
+                pass
+
+        return tmp.name, _cleanup
+
+    raise TypeError("Unsupported video input type; expected path or file-like object")
+
+
+def _compute_fps(cap: cv2.VideoCapture) -> float:
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    if not fps or np.isnan(fps) or fps <= 0:
+        logger.warning("Falling back to default FPS=30.0 (metadata missing)")
+        return 30.0
+    return float(fps)
+
+
+def _fps_step(src_fps: float, fps_cap: float) -> int:
+    if fps_cap <= 0:
+        return 1
+    return max(1, int(round(src_fps / fps_cap)))
+
+
+def iter_frames(video_input: VideoInput, cfg: Dict[str, Any]) -> Iterable[FrameYield]:
+    """Yield frames from ``video_input`` with timestamps and frame indices.
+
+    Parameters
+    ----------
+    video_input:
+        Filesystem path or file-like object containing a video.
+    cfg:
+        Runtime configuration dictionary. Must contain ``fps_cap``.
+
+    Yields
+    ------
+    tuple[np.ndarray, int, int, float]
+        Frame in BGR, timestamp (ms), frame index, and source FPS.
+    """
+
+    video_path, cleanup = _resolve_video_input(video_input)
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        if cleanup:
+            cleanup()
+        raise RuntimeError(f"Could not open video file: {video_path}")
+
+    src_fps = _compute_fps(cap)
+    fps_cap = float(cfg.get("fps_cap", src_fps))
+    step = _fps_step(src_fps, fps_cap)
+    logger.info(
+        "Iterating frames with src_fps=%.2f, fps_cap=%.2f, step=%d", src_fps, fps_cap, step
+    )
+
+    def _generator() -> Iterator[FrameYield]:
+        try:
+            frame_idx = 0
+            while True:
+                success, frame = cap.read()
+                if not success or frame is None:
+                    break
+
+                if frame_idx % step == 0:
+                    t_ms = int(round((frame_idx / src_fps) * 1000.0))
+                    yield frame, t_ms, frame_idx, src_fps
+
+                frame_idx += 1
+        finally:
+            cap.release()
+            if cleanup:
+                cleanup()
+
+    return _generator()
+
+
+def extract(video_input: VideoInput, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract a :class:`PoseTimeSeries` using MediaPipe Pose Landmarker 3D."""
+
+    model_path = cfg.get("models", {}).get("pose_landmarker_path")
+    if not model_path:
+        raise FileNotFoundError("Pose Landmarker model path missing in configuration")
+
+    model_path = Path(model_path)
+    if not model_path.exists():
+        raise FileNotFoundError(f"Pose Landmarker model not found: {model_path}")
+
+    fps_cap = float(cfg.get("fps_cap", 30.0))
+
+    options = vision.PoseLandmarkerOptions(
+        base_options=python.BaseOptions(model_asset_path=str(model_path)),
+        running_mode=vision.RunningMode.VIDEO,
+        output_segmentation_masks=False,
+    )
+
+    frames: list[Dict[str, Any]] = []
+    src_fps: Optional[float] = None
+
+    with vision.PoseLandmarker.create_from_options(options) as landmarker:
+        for frame_bgr, t_ms, frame_idx, src_fps_value in iter_frames(video_input, cfg):
+            if src_fps is None:
+                src_fps = src_fps_value
+            frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+            mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=frame_rgb)
+            result = landmarker.detect_for_video(mp_image, t_ms)
+
+            pose_frame: Dict[str, Any] = {
+                "frame_idx": int(frame_idx),
+                "t": float(t_ms) / 1000.0,
+                "landmarks": {},
+                "conf": 0.0,
+            }
+
+            if result.pose_world_landmarks:
+                world_landmarks = result.pose_world_landmarks[0]
+                pose_frame["landmarks"] = {
+                    PoseLandmark(i).name: {
+                        "x": float(lmk.x),
+                        "y": float(lmk.y),
+                        "z": float(lmk.z),
+                        "visibility": float(getattr(lmk, "visibility", 1.0)),
+                        "presence": float(getattr(lmk, "presence", 1.0)),
+                    }
+                    for i, lmk in enumerate(world_landmarks.landmark)
+                }
+                pose_frame["conf"] = 1.0
+            else:
+                logger.warning("No pose detected at frame_idx=%d (t=%.3fs)", frame_idx, pose_frame["t"])
+
+            frames.append(pose_frame)
+
+    if src_fps is None:
+        raise RuntimeError("No frames processed; video may be empty or unreadable")
+
+    step = _fps_step(src_fps, fps_cap)
+    effective_fps = src_fps / step
+
+    logger.info("Pose extraction complete: %d frames (effective_fps=%.2f)", len(frames), effective_fps)
+
+    return {
+        "fps": float(effective_fps),
+        "frames": frames,
+    }


### PR DESCRIPTION
## Summary
- implement the MediaPipe Pose Landmarker 3D wrapper with frame iteration and PoseTimeSeries output
- wire pose extraction into the Streamlit Analyze flow and surface the processed-frame success message
- record task completion for T02.1–T02.3 in the task list ledger

## Testing
- python -m compileall ml/pose3d.py app/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e67c781b648320a374c3b88b8db547